### PR TITLE
Add Volleyball Stats Messenger planning docs

### DIFF
--- a/adr/0001-problem-and-scope.md
+++ b/adr/0001-problem-and-scope.md
@@ -1,0 +1,24 @@
+# ADR-0001 Problem and Scope for Volleyball Stats Messenger
+
+**Status**: Accepted  
+**Date**: 2025-09-23
+
+## Context
+Coaches need a fast, auditable way to deliver plain-text stat reports to players via email. MVP must prioritize speed, reliability, and security over visualization. Players require a secure history of reports.
+
+## Decision
+- Deliver **plain-text** report flow (manual entry + CSV ingestion) with **email delivery** and **secure signed links**.
+- Use **DynamoDB single-table** for low-latency timelines; store report text in **S3**.
+- Protect endpoints with **Cognito JWT** and **WAF**; encrypt at rest with **KMS**.
+- Capture **AUDIT** items for both send and view events.
+- Define **SLOs**: reads p95 < 200 ms; CSV→email < 60 s; 99.9% availability.
+
+## Alternatives Considered
+- **Aurora Postgres first**: easier ad-hoc analytics, joins; **cons**: higher read latency for timelines, more ops overhead.
+- **Charts & PDFs v1**: richer UX; **cons**: slows time-to-value, heavier pipeline.
+- **Email attachments** instead of links: simpler delivery; **cons**: loss of centralized revocation/audit, larger email footprint.
+
+## Consequences
+**Pros**: Simple UX, fast reads, straightforward email delivery, strong auditability, easy to scale writes.  
+**Cons**: Requires careful Dynamo modeling; no charts in v1; CSV quality control is mandatory.  
+**Follow-ups**: Week-2 implement manual send API & SES; Week-3 CSV pipeline; consider Aur

--- a/docs/data/dynamodb-single-table-draft.md
+++ b/docs/data/dynamodb-single-table-draft.md
@@ -1,0 +1,82 @@
+# DynamoDB Single-Table Draft
+
+**Table**: `vsm-main`  
+**Primary Key**: `PK` (partition), `SK` (sort)  
+**GSIs**: `GSI1` (reportId lookup), `GSI2` (team timeline — optional)
+
+## Access Patterns
+1. **List a player’s reports** (reverse chronological)
+2. **Get a specific report** by `reportId`
+3. **List a team’s reports** (coach/team view)
+4. **Audit trail** per report (who sent/viewed/when)
+
+## Item Shapes
+### PLAYER
+PK = PLAYER#p_alex_li_12
+SK = PROFILE#p_alex_li_12
+email = "alex.li@example.edu"
+name = "Alex Li"
+teamId = "t_uic_mens_2025"
+
+### REPORT
+PK = PLAYER#<playerId>
+SK = REPORT#<yyyyMMddHHmmss>#<reportId>
+reportId, playerId, teamId, coachId, categories, s3Key, createdAt
+GSI1PK = REPORT#<reportId>
+GSI1SK = REPORT#<reportId>
+GSI2PK = TEAM#<teamId> (optional)
+GSI2SK = CREATED#<yyyyMMddHHmmss>#<reportId>
+
+### AUDIT
+PK = REPORT#<reportId>
+SK = AUDIT#<timestamp>Z#<eventType> # SENT | VIEWED
+actorId, actorRole, ip, userAgent, correlationId?
+
+## Example Items
+```json
+{
+  "PK": "PLAYER#p_alex_li_12",
+  "SK": "PROFILE#p_alex_li_12",
+  "email": "alex.li@example.edu",
+  "name": "Alex Li",
+  "teamId": "t_uic_mens_2025"
+}
+{
+  "PK": "PLAYER#p_alex_li_12",
+  "SK": "REPORT#20250922T221530#r_0001",
+  "reportId": "r_0001",
+  "playerId": "p_alex_li_12",
+  "teamId": "t_uic_mens_2025",
+  "coachId": "c_mendez_001",
+  "categories": {"Aces": 3, "Digs": 17, "Blocks": 2},
+  "s3Key": "reports/p_alex_li_12/2025/09/22/r_0001.txt",
+  "createdAt": "2025-09-22T22:15:30Z",
+  "GSI1PK": "REPORT#r_0001",
+  "GSI1SK": "REPORT#r_0001",
+  "GSI2PK": "TEAM#t_uic_mens_2025",
+  "GSI2SK": "CREATED#20250922T221530#r_0001"
+}
+{
+  "PK": "REPORT#r_0001",
+  "SK": "AUDIT#20250922T221532Z#SENT",
+  "actorId": "c_mendez_001",
+  "actorRole": "COACH",
+  "ip": "203.0.113.10",
+  "userAgent": "Mozilla/5.0"
+}
+{
+  "PK": "REPORT#r_0001",
+  "SK": "AUDIT#20250922T223001Z#VIEWED",
+  "actorId": "p_alex_li_12",
+  "actorRole": "PLAYER",
+  "ip": "198.51.100.23",
+  "userAgent": "Mobile Safari/17.0"
+}
+```
+Typical Queries (pseudo)
+Player history: Query PK = PLAYER#p_alex_li_12 AND begins_with(SK, "REPORT#") ORDER BY desc
+Get report by id: Query GSI1 where GSI1PK = REPORT#r_0001
+Team history: Query GSI2 where GSI2PK = TEAM#t_uic_mens_2025 ORDER BY desc
+Audit for a report: Query PK = REPORT#r_0001 AND begins_with(SK, "AUDIT#")
+Idempotency
+Client supplies reportId; perform conditional put: attribute_not_exists(PK) AND attribute_not_exists(SK).

--- a/docs/diagrams/components.md
+++ b/docs/diagrams/components.md
@@ -1,0 +1,29 @@
+# Component Diagram (Mermaid)
+
+```mermaid
+flowchart TB
+  subgraph Frontend
+    A[Angular App\nRoutes, Guard, JWT Interceptor, Forms]
+  end
+
+  subgraph Services
+    B[Spring Boot API\nControllers, Services, Security, OpenAPI, Actuator]
+    C[Lambda csv-validate (TS)]
+    D[Lambda persist-batch (TS)]
+    E[Lambda notify-report-ready (TS)]
+    F[Step Functions Orchestrator]
+  end
+
+  subgraph Data
+    G[(DynamoDB: Single Table)]
+    H[(S3: raw uploads & .txt reports)]
+  end
+
+  A --> B
+  B --> G
+  B --> H
+  B --> F
+  F --> C
+  F --> D
+  F --> E
+```

--- a/docs/diagrams/context.md
+++ b/docs/diagrams/context.md
@@ -1,0 +1,16 @@
+# Context Diagram (Mermaid)
+
+```mermaid
+flowchart LR
+  Coach((Coach c_mendez_001)) -- JWT --> Angular[Angular Portal]
+  Player((Player p_alex_li_12)) -- JWT --> Angular
+  Angular -- HTTPS --> API[(Spring Boot API on ALB)]
+  API -- read/write --> DDB[(DynamoDB: vsm-main)]
+  API -- put/get --> S3[(S3: vsm-raw-uploads / vsm-report-texts)]
+  API -- events --> EB[EventBridge]
+  EB -- triggers --> SFN[Step Functions]
+  SFN -- invokes --> Lmb[Lambda: csv-validate / persist / notify]
+  Lmb -- send --> SES[SES (no-reply@vsm.example.com)]
+  API -. traces/logs .- CW[(CloudWatch/X-Ray)]
+  API -. auth .- Cognito[(Cognito Hosted UI/JWT)]
+```

--- a/docs/diagrams/sequence-coach-sends-stats.md
+++ b/docs/diagrams/sequence-coach-sends-stats.md
@@ -1,0 +1,23 @@
+# Sequence Diagram — Coach Sends Stats (Manual)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Coach as Coach (c_mendez_001)
+  participant Angular as Angular Portal
+  participant API as Spring API
+  participant DDB as DynamoDB (vsm-main)
+  participant S3 as S3 (vsm-report-texts)
+  participant EB as EventBridge
+  participant L as Lambda (notify-report-ready)
+  participant SES as SES (no-reply@vsm.example.com)
+
+  Coach->>Angular: Submit Stats Form (playerId=p_alex_li_12, categories)
+  Angular->>API: POST /coach/reports (JWT)
+  API->>DDB: Conditional Put REPORT (idempotency on reportId)
+  API->>S3: PutObject .txt (KMS-encrypted)
+  API->>EB: PutEvents report.created
+  EB->>L: Invoke notify-report-ready
+  L->>SES: Send Email (signed S3 link)
+  API-->>Angular: 201 Created {reportId}
+```

--- a/docs/one-pager.md
+++ b/docs/one-pager.md
@@ -1,0 +1,55 @@
+# One-Pager — Volleyball Stats Messenger (Coach → Player)
+
+**Product**: Volleyball Stats Messenger  
+**Team**: `t_uic_mens_2025` — UIC Men's Volleyball 2025  
+**Date**: 2025-09-23
+
+## Problem
+Coaches need a fast way to send players simple, auditable stat reports via email. Existing tools are visual-first and slow to distribute. We optimize for **speed, reliability, and auditability** with **plain-text** reports in a secure, role-based system.
+
+## Users & Roles
+- **Coach (COACH)** — creates/ingests stats, sends reports, views team history. Example: `c_mendez_001` — Coach Luis Mendez
+- **Player (PLAYER)** — views personal report history and individual report text. Example: `p_alex_li_12` — Alex Li
+- **System** — validates CSV, generates `.txt`, stores in S3, emails signed link via SES.
+
+## Top Use Cases
+1. Coach manually enters stats for a player and clicks **Send**.
+2. Coach uploads a CSV; system validates/normalizes rows and emails each player their report.
+3. Player opens email link to their `.txt` report and can browse prior reports in the portal.
+4. Coach audits who received/viewed which report and when.
+
+## Acceptance Criteria (Given/When/Then)
+**Manual Send**
+- *Given* `c_mendez_001` is authenticated with COACH role,
+- *When* they submit a valid stats form for `p_alex_li_12`,
+- *Then* the system saves a REPORT item, writes a `.txt` to S3 (`vsm-report-texts`), sends an SES email to `alex.li@example.edu` with a signed link, and writes an AUDIT record for **SENT**.
+
+**CSV Upload**
+- *Given* a CSV is uploaded to `vsm-raw-uploads` via a presigned URL,
+- *When* the pipeline validates and processes it,
+- *Then* invalid rows are rejected with a clear error file; valid rows produce REPORTs, `.txt` files, SES emails, and **AUDIT** events. Failures go to DLQ with retries/backoff.
+
+**Player Access**
+- *Given* `p_alex_li_12` is authenticated with PLAYER role,
+- *When* they view **My Reports**,
+- *Then* they see only their own reports (reverse chronological) and can open the secure `.txt` link. All views are audited.
+
+**Auditability**
+- *Given* a sent or viewed report,
+- *When* a coach queries audit for that report,
+- *Then* the system returns who sent/viewed and timestamps with correlation IDs.
+
+## Non-Functionals (SLO Targets)
+- **Reads**: `GET /players/{id}/reports` p95 < **200 ms**.
+- **Ingest**: 5k-row CSV end-to-end < **60 s**.
+- **Availability**: **99.9%** monthly.
+- **Security**: Cognito JWT (RBAC), KMS-encrypted S3/Dynamo, WAF in front of API edges.
+- **Observability**: Correlated logs/metrics/traces; alarms on 5xx & SLO burn rate.
+
+## Out of Scope (v1)
+Rich charts/visualization, mobile apps, offline mode, multi-sport support, bulk team admin UI beyond basics.
+
+## Risks & Mitigations
+- **Email deliverability (SES)** → Domain verification, warm-up, bounce/complaint handling, link expiration.  
+- **CSV quality** → Strong schema validation (Ajv/Zod), clear error report, Step Functions retries, SQS DLQ.  
+- **Access** → JWT RBAC & policy checks; WAF, least-privilege IAM; KMS on S3/Dynamo; CORS lockdown.


### PR DESCRIPTION
## Summary
- add product one-pager outlining goals, roles, use cases, and risks
- document architecture diagrams covering context, components, and coach send sequence
- capture DynamoDB single-table modeling draft and ADR for problem and scope

## Testing
- not run (documentation-only change)