### PR TITLE
feat: add day 2 terraform infrastructure scaffolding

### DIFF
--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,3 +1,19 @@
-# Terraform Infrastructure
+# Terraform Infra — Day 2
 
-Terraform modules and environment configurations are organized in this directory.
+This completes Day 2 scaffolding with secure-by-default modules:
+
+- **VPC**: 2 public + 2 private subnets, IGW, 1 NAT, routes
+- **S3**: raw + reports buckets, **KMS SSE**, **versioning**, **TLS-only policy**, **public access blocked**
+- **DynamoDB**: PK/SK, **GSI1** (reportId), optional **GSI2** (team), **PITR**, **KMS SSE**
+- **Cognito**: user pool + app client (code flow), email as username
+- **ECR**: repository for players-api (scan on push)
+- **IAM**: ECS task exec/task roles, Lambda role with least-privilege placeholders
+
+## Dev Usage
+```bash
+cd infra/terraform/envs/dev
+terraform init
+terraform plan
+terraform apply
+```
+Adjust names in variables.tf (or create dev.auto.tfvars) if needed (S3 bucket names must be globally unique).

--- a/infra/terraform/envs/dev/README.md
+++ b/infra/terraform/envs/dev/README.md
@@ -1,3 +1,7 @@
-# Development Environment
+# Dev Environment
 
-Instructions for deploying the development environment will be documented here.
+1) `terraform init`  
+2) `terraform plan`  
+3) `terraform apply`
+
+> Buckets must be globally unique. Set unique names in `variables.tf` or create `dev.auto.tfvars`.

--- a/infra/terraform/envs/dev/main.tf
+++ b/infra/terraform/envs/dev/main.tf
@@ -1,1 +1,61 @@
-# Placeholder for dev environment resources
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "~> 5.0" }
+  }
+}
+
+provider "aws" { region = var.region }
+
+module "vpc" {
+  source               = "../../modules/vpc"
+  name                 = var.name_prefix
+  cidr_block           = "10.0.0.0/16"
+  azs                  = ["us-east-1a","us-east-1b"]
+  public_subnet_cidrs  = ["10.0.1.0/24","10.0.2.0/24"]
+  private_subnet_cidrs = ["10.0.11.0/24","10.0.12.0/24"]
+}
+
+module "s3" {
+  source             = "../../modules/s3"
+  name_prefix        = var.name_prefix
+  raw_bucket_name    = var.raw_bucket_name
+  report_bucket_name = var.report_bucket_name
+}
+
+module "ddb" {
+  source        = "../../modules/dynamodb"
+  table_name    = var.ddb_table_name
+  kms_key_arn   = module.s3.kms_key_arn
+  with_team_gsi = true
+}
+
+module "cognito" {
+  source      = "../../modules/cognito"
+  name_prefix = var.name_prefix
+}
+
+module "ecr" {
+  source    = "../../modules/ecr"
+  repo_name = "players-api"
+}
+
+module "iam" {
+  source                 = "../../modules/iam"
+  name_prefix            = var.name_prefix
+  ddb_table_arn          = module.ddb.table_arn
+  s3_reports_bucket_arn  = "arn:aws:s3:::${var.report_bucket_name}"
+  s3_raw_bucket_arn      = "arn:aws:s3:::${var.raw_bucket_name}"
+}
+
+output "vpc_id"                { value = module.vpc.vpc_id }
+output "public_subnets"        { value = module.vpc.public_subnet_ids }
+output "private_subnets"       { value = module.vpc.private_subnet_ids }
+output "s3_raw_bucket"         { value = module.s3.raw_bucket }
+output "s3_reports_bucket"     { value = module.s3.reports_bucket }
+output "ddb_table_name"        { value = module.ddb.table_name }
+output "cognito_user_pool_id"  { value = module.cognito.user_pool_id }
+output "cognito_app_client_id" { value = module.cognito.app_client_id }
+output "ecr_repo"              { value = module.ecr.repository_name }
+output "ecs_task_role"         { value = module.iam.ecs_task_role_name }
+output "lambda_role"           { value = module.iam.lambda_role_name }

--- a/infra/terraform/envs/dev/variables.tf
+++ b/infra/terraform/envs/dev/variables.tf
@@ -1,1 +1,7 @@
-# Placeholder for dev environment variables
+variable "region" { default = "us-east-1" }
+variable "name_prefix" { default = "vsm-dev" }
+variable "raw_bucket_name" { default = "vsm-raw-uploads" }
+variable "report_bucket_name" { default = "vsm-report-texts" }
+variable "ddb_table_name" { default = "vsm-main" }
+
+# ⚠️ Change the two S3 bucket names to globally unique values (e.g., add your initials) here or create dev.auto.tfvars with overrides.

--- a/infra/terraform/modules/cognito/main.tf
+++ b/infra/terraform/modules/cognito/main.tf
@@ -1,1 +1,23 @@
-# Placeholder for cognito module resources
+resource "aws_cognito_user_pool" "this" {
+  name = "${var.name_prefix}-user-pool"
+  username_attributes = ["email"]
+  auto_verified_attributes = ["email"]
+  password_policy { minimum_length = 8 }
+}
+
+resource "aws_cognito_user_pool_client" "app" {
+  name         = "${var.name_prefix}-app-client"
+  user_pool_id = aws_cognito_user_pool.this.id
+  allowed_oauth_flows       = ["code"]
+  allowed_oauth_scopes      = ["email", "openid", "profile"]
+  allowed_oauth_flows_user_pool_client = true
+  generate_secret           = false
+  callback_urls             = ["http://localhost:4200/callback"]
+  logout_urls               = ["http://localhost:4200"]
+  supported_identity_providers = ["COGNITO"]
+  explicit_auth_flows = ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+}
+
+output "user_pool_id"     { value = aws_cognito_user_pool.this.id }
+output "user_pool_arn"    { value = aws_cognito_user_pool.this.arn }
+output "app_client_id"    { value = aws_cognito_user_pool_client.app.id }

--- a/infra/terraform/modules/cognito/variables.tf
+++ b/infra/terraform/modules/cognito/variables.tf
@@ -1,1 +1,1 @@
-# Placeholder for cognito module variables
+variable "name_prefix" { type = string }

--- a/infra/terraform/modules/dynamodb/main.tf
+++ b/infra/terraform/modules/dynamodb/main.tf
@@ -1,1 +1,37 @@
-# Placeholder for dynamodb module resources
+resource "aws_dynamodb_table" "this" {
+  name         = var.table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "PK"
+  range_key    = "SK"
+
+  attribute { name = "PK"; type = "S" }
+  attribute { name = "SK"; type = "S" }
+  attribute { name = "GSI1PK"; type = "S" }
+  attribute { name = "GSI1SK"; type = "S" }
+
+  global_secondary_index {
+    name            = "GSI1"
+    hash_key        = "GSI1PK"
+    range_key       = "GSI1SK"
+    projection_type = "ALL"
+  }
+
+  dynamic "global_secondary_index" {
+    for_each = var.with_team_gsi ? [1] : []
+    content {
+      name            = "GSI2"
+      hash_key        = "GSI2PK"
+      range_key       = "GSI2SK"
+      projection_type = "ALL"
+    }
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = var.kms_key_arn
+  }
+
+  point_in_time_recovery { enabled = true }
+
+  tags = { Name = var.table_name }
+}

--- a/infra/terraform/modules/dynamodb/outputs.tf
+++ b/infra/terraform/modules/dynamodb/outputs.tf
@@ -1,1 +1,2 @@
-# Placeholder for dynamodb module outputs
+output "table_name" { value = aws_dynamodb_table.this.name }
+output "table_arn"  { value = aws_dynamodb_table.this.arn }

--- a/infra/terraform/modules/dynamodb/variables.tf
+++ b/infra/terraform/modules/dynamodb/variables.tf
@@ -1,1 +1,3 @@
-# Placeholder for dynamodb module variables
+variable "table_name" { type = string }
+variable "kms_key_arn" { type = string }
+variable "with_team_gsi" { type = bool default = true }

--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -1,1 +1,8 @@
-# Placeholder for ecr module resources
+resource "aws_ecr_repository" "this" {
+  name = var.repo_name
+  image_scanning_configuration { scan_on_push = true }
+  encryption_configuration { encryption_type = "AES256" }
+  force_delete = true
+}
+
+output "repository_url" { value = aws_ecr_repository.this.repository_url }

--- a/infra/terraform/modules/ecr/outputs.tf
+++ b/infra/terraform/modules/ecr/outputs.tf
@@ -1,1 +1,1 @@
-# Placeholder for ecr module outputs
+output "repository_name" { value = aws_ecr_repository.this.name }

--- a/infra/terraform/modules/ecr/variables.tf
+++ b/infra/terraform/modules/ecr/variables.tf
@@ -1,1 +1,1 @@
-# Placeholder for ecr module variables
+variable "repo_name" { type = string }

--- a/infra/terraform/modules/iam/main.tf
+++ b/infra/terraform/modules/iam/main.tf
@@ -1,0 +1,71 @@
+// ECS task execution role
+resource "aws_iam_role" "ecs_task_execution" {
+  name = "${var.name_prefix}-ecs-task-exec"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{ Effect = "Allow", Principal = { Service = "ecs-tasks.amazonaws.com" }, Action = "sts:AssumeRole" }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_exec_policy" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+// ECS task role (app permissions — least-privilege placeholders)
+resource "aws_iam_role" "ecs_task" {
+  name = "${var.name_prefix}-ecs-task"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{ Effect = "Allow", Principal = { Service = "ecs-tasks.amazonaws.com" }, Action = "sts:AssumeRole" }]
+  })
+}
+
+resource "aws_iam_policy" "ecs_task_app" {
+  name = "${var.name_prefix}-ecs-task-app"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      { Effect = "Allow", Action = ["dynamodb:PutItem","dynamodb:Query","dynamodb:GetItem","dynamodb:UpdateItem"], Resource = [var.ddb_table_arn, "${var.ddb_table_arn}/index/*"] },
+      { Effect = "Allow", Action = ["s3:PutObject","s3:GetObject"], Resource = ["${var.s3_reports_bucket_arn}/*"] },
+      { Effect = "Allow", Action = ["events:PutEvents"], Resource = "*" },
+      { Effect = "Allow", Action = ["xray:PutTraceSegments","xray:PutTelemetryRecords"], Resource = "*" }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_app_attach" {
+  role       = aws_iam_role.ecs_task.name
+  policy_arn = aws_iam_policy.ecs_task_app.arn
+}
+
+// Lambda basic role (reuse for csv-validate/notify)
+resource "aws_iam_role" "lambda_basic" {
+  name = "${var.name_prefix}-lambda-basic"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{ Effect = "Allow", Principal = { Service = "lambda.amazonaws.com" }, Action = "sts:AssumeRole" }]
+  })
+}
+
+resource "aws_iam_policy" "lambda_policy" {
+  name = "${var.name_prefix}-lambda-policy"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      { Effect = "Allow", Action = ["logs:CreateLogGroup","logs:CreateLogStream","logs:PutLogEvents"], Resource = "*" },
+      { Effect = "Allow", Action = ["s3:GetObject","s3:PutObject"], Resource = ["${var.s3_raw_bucket_arn}/*","${var.s3_reports_bucket_arn}/*"] },
+      { Effect = "Allow", Action = ["dynamodb:BatchWriteItem","dynamodb:PutItem","dynamodb:UpdateItem"], Resource = var.ddb_table_arn },
+      { Effect = "Allow", Action = ["events:PutEvents","ses:SendEmail","ses:SendRawEmail"], Resource = "*" }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_policy_attach" {
+  role       = aws_iam_role.lambda_basic.name
+  policy_arn = aws_iam_policy.lambda_policy.arn
+}
+
+output "ecs_task_execution_role_arn" { value = aws_iam_role.ecs_task_execution.arn }
+output "ecs_task_role_arn"           { value = aws_iam_role.ecs_task.arn }
+output "lambda_role_arn"             { value = aws_iam_role.lambda_basic.arn }

--- a/infra/terraform/modules/iam/outputs.tf
+++ b/infra/terraform/modules/iam/outputs.tf
@@ -1,0 +1,3 @@
+output "ecs_task_execution_role_name" { value = aws_iam_role.ecs_task_execution.name }
+output "ecs_task_role_name" { value = aws_iam_role.ecs_task.name }
+output "lambda_role_name" { value = aws_iam_role.lambda_basic.name }

--- a/infra/terraform/modules/iam/variables.tf
+++ b/infra/terraform/modules/iam/variables.tf
@@ -1,0 +1,4 @@
+variable "name_prefix" { type = string }
+variable "ddb_table_arn" { type = string }
+variable "s3_reports_bucket_arn" { type = string }
+variable "s3_raw_bucket_arn" { type = string }

--- a/infra/terraform/modules/s3/main.tf
+++ b/infra/terraform/modules/s3/main.tf
@@ -1,1 +1,63 @@
-# Placeholder for s3 module resources
+// KMS Key for S3 SSE
+resource "aws_kms_key" "s3" {
+  description = "${var.name_prefix} S3 KMS key"
+  deletion_window_in_days = 7
+}
+
+locals {
+  buckets = {
+    raw     = var.raw_bucket_name
+    reports = var.report_bucket_name
+  }
+}
+
+// Create two buckets: raw uploads + report texts
+resource "aws_s3_bucket" "b" {
+  for_each = local.buckets
+  bucket   = each.value
+}
+
+resource "aws_s3_bucket_public_access_block" "b" {
+  for_each = aws_s3_bucket.b
+  bucket                  = each.value.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "sse" {
+  for_each = aws_s3_bucket.b
+  bucket   = each.value.id
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.s3.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "v" {
+  for_each = aws_s3_bucket.b
+  bucket   = each.value.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket_policy" "tls_only" {
+  for_each = aws_s3_bucket.b
+  bucket   = each.value.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Sid = "DenyInsecureTransport",
+      Effect = "Deny",
+      Principal = "*",
+      Action = "s3:*",
+      Resource = [
+        each.value.arn,
+        "${each.value.arn}/*"
+      ],
+      Condition = { Bool = { "aws:SecureTransport" = "false" } }
+    }]
+  })
+}

--- a/infra/terraform/modules/s3/outputs.tf
+++ b/infra/terraform/modules/s3/outputs.tf
@@ -1,1 +1,3 @@
-# Placeholder for s3 module outputs
+output "kms_key_arn" { value = aws_kms_key.s3.arn }
+output "raw_bucket" { value = aws_s3_bucket.b["raw"].id }
+output "reports_bucket" { value = aws_s3_bucket.b["reports"].id }

--- a/infra/terraform/modules/s3/variables.tf
+++ b/infra/terraform/modules/s3/variables.tf
@@ -1,1 +1,3 @@
-# Placeholder for s3 module variables
+variable "name_prefix" { type = string }
+variable "raw_bucket_name" { type = string }
+variable "report_bucket_name" { type = string }

--- a/infra/terraform/modules/vpc/main.tf
+++ b/infra/terraform/modules/vpc/main.tf
@@ -1,1 +1,61 @@
-# Placeholder for vpc module resources
+// VPC with 2 public + 2 private subnets, IGW, 1 NAT
+resource "aws_vpc" "this" {
+  cidr_block           = var.cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags = { Name = "${var.name}-vpc" }
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.this.id
+  tags = { Name = "${var.name}-igw" }
+}
+
+resource "aws_eip" "nat" { domain = "vpc" }
+
+resource "aws_subnet" "public" {
+  for_each = { for idx, cidr in var.public_subnet_cidrs : idx => cidr }
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = each.value
+  availability_zone       = var.azs[tonumber(each.key)]
+  map_public_ip_on_launch = true
+  tags = { Name = "${var.name}-public-${each.key}" }
+}
+
+resource "aws_subnet" "private" {
+  for_each = { for idx, cidr in var.private_subnet_cidrs : idx => cidr }
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = each.value
+  availability_zone = var.azs[tonumber(each.key)]
+  tags = { Name = "${var.name}-private-${each.key}" }
+}
+
+resource "aws_nat_gateway" "nat" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = values(aws_subnet.public)[0].id
+  tags = { Name = "${var.name}-nat" }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+  route { cidr_block = "0.0.0.0/0" gateway_id = aws_internet_gateway.igw.id }
+  tags = { Name = "${var.name}-public-rt" }
+}
+
+resource "aws_route_table_association" "public" {
+  for_each       = aws_subnet.public
+  route_table_id = aws_route_table.public.id
+  subnet_id      = each.value.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+  route { cidr_block = "0.0.0.0/0" nat_gateway_id = aws_nat_gateway.nat.id }
+  tags = { Name = "${var.name}-private-rt" }
+}
+
+resource "aws_route_table_association" "private" {
+  for_each       = aws_subnet.private
+  route_table_id = aws_route_table.private.id
+  subnet_id      = each.value.id
+}

--- a/infra/terraform/modules/vpc/outputs.tf
+++ b/infra/terraform/modules/vpc/outputs.tf
@@ -1,1 +1,3 @@
-# Placeholder for vpc module outputs
+output "vpc_id" { value = aws_vpc.this.id }
+output "public_subnet_ids" { value = [for s in aws_subnet.public : s.id] }
+output "private_subnet_ids" { value = [for s in aws_subnet.private : s.id] }

--- a/infra/terraform/modules/vpc/variables.tf
+++ b/infra/terraform/modules/vpc/variables.tf
@@ -1,1 +1,5 @@
-# Placeholder for vpc module variables
+variable "name" { type = string }
+variable "cidr_block" { type = string }
+variable "azs" { type = list(string) }
+variable "public_subnet_cidrs" { type = list(string) }
+variable "private_subnet_cidrs" { type = list(string) }


### PR DESCRIPTION
## Summary
- implement VPC, S3, DynamoDB, Cognito, ECR, and IAM modules with secure defaults
- configure the dev environment to consume the new modules and document usage steps

## Testing
- not run (terraform CLI not available in the environment)