### PR TITLE
Update dev S3 bucket names with initials

### DIFF
--- a/infra/terraform/envs/dev/variables.tf
+++ b/infra/terraform/envs/dev/variables.tf
@@ -1,7 +1,7 @@
 variable "region" { default = "us-east-1" }
 variable "name_prefix" { default = "vsm-dev" }
-variable "raw_bucket_name" { default = "vsm-raw-uploads" }
-variable "report_bucket_name" { default = "vsm-report-texts" }
+variable "raw_bucket_name" { default = "vsm-raw-uploads-pq-dev" }
+variable "report_bucket_name" { default = "vsm-report-texts-pq-dev" }
 variable "ddb_table_name" { default = "vsm-main" }
 
 # ⚠️ Change the two S3 bucket names to globally unique values (e.g., add your initials) here or create dev.auto.tfvars with overrides.


### PR DESCRIPTION
## Summary
- update the dev environment raw and report S3 bucket defaults to include the pq initials so the names are globally unique

## Testing
- not run