### PR TITLE
infra: KMS key policy for DDB + ECS/Lambda KMS perms; VPC/HCL cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,14 @@
 # TODO: add project-specific ignore patterns
+# Terraform
+**/.terraform/
+**/.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+# Local plans
+tfplan
+*.plan

--- a/infra/terraform/envs/dev/main.tf
+++ b/infra/terraform/envs/dev/main.tf
@@ -11,9 +11,9 @@ module "vpc" {
   source               = "../../modules/vpc"
   name                 = var.name_prefix
   cidr_block           = "10.0.0.0/16"
-  azs                  = ["us-east-1a","us-east-1b"]
-  public_subnet_cidrs  = ["10.0.1.0/24","10.0.2.0/24"]
-  private_subnet_cidrs = ["10.0.11.0/24","10.0.12.0/24"]
+  azs                  = ["us-east-1a", "us-east-1b"]
+  public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_subnet_cidrs = ["10.0.11.0/24", "10.0.12.0/24"]
 }
 
 module "s3" {
@@ -41,21 +41,22 @@ module "ecr" {
 }
 
 module "iam" {
-  source                 = "../../modules/iam"
-  name_prefix            = var.name_prefix
-  ddb_table_arn          = module.ddb.table_arn
-  s3_reports_bucket_arn  = "arn:aws:s3:::${var.report_bucket_name}"
-  s3_raw_bucket_arn      = "arn:aws:s3:::${var.raw_bucket_name}"
+  source                = "../../modules/iam"
+  name_prefix           = var.name_prefix
+  ddb_table_arn         = module.ddb.table_arn
+  s3_reports_bucket_arn = "arn:aws:s3:::${var.report_bucket_name}"
+  s3_raw_bucket_arn     = "arn:aws:s3:::${var.raw_bucket_name}"
+  kms_key_arn           = module.s3.kms_key_arn
 }
 
-output "vpc_id"                { value = module.vpc.vpc_id }
-output "public_subnets"        { value = module.vpc.public_subnet_ids }
-output "private_subnets"       { value = module.vpc.private_subnet_ids }
-output "s3_raw_bucket"         { value = module.s3.raw_bucket }
-output "s3_reports_bucket"     { value = module.s3.reports_bucket }
-output "ddb_table_name"        { value = module.ddb.table_name }
-output "cognito_user_pool_id"  { value = module.cognito.user_pool_id }
+output "vpc_id" { value = module.vpc.vpc_id }
+output "public_subnets" { value = module.vpc.public_subnet_ids }
+output "private_subnets" { value = module.vpc.private_subnet_ids }
+output "s3_raw_bucket" { value = module.s3.raw_bucket }
+output "s3_reports_bucket" { value = module.s3.reports_bucket }
+output "ddb_table_name" { value = module.ddb.table_name }
+output "cognito_user_pool_id" { value = module.cognito.user_pool_id }
 output "cognito_app_client_id" { value = module.cognito.app_client_id }
-output "ecr_repo"              { value = module.ecr.repository_name }
-output "ecs_task_role"         { value = module.iam.ecs_task_role_name }
-output "lambda_role"           { value = module.iam.lambda_role_name }
+output "ecr_repo" { value = module.ecr.repository_name }
+output "ecs_task_role" { value = module.iam.ecs_task_role_name }
+output "lambda_role" { value = module.iam.lambda_role_name }

--- a/infra/terraform/modules/dynamodb/main.tf
+++ b/infra/terraform/modules/dynamodb/main.tf
@@ -1,29 +1,48 @@
 resource "aws_dynamodb_table" "this" {
   name         = var.table_name
   billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "PK"
-  range_key    = "SK"
 
-  attribute { name = "PK"; type = "S" }
-  attribute { name = "SK"; type = "S" }
-  attribute { name = "GSI1PK"; type = "S" }
-  attribute { name = "GSI1SK"; type = "S" }
+  hash_key  = "pk"
+  range_key = "sk"
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+
+  attribute {
+    name = "reportId"
+    type = "S"
+  }
+
+  attribute {
+    name = "team"
+    type = "S"
+  }
 
   global_secondary_index {
-    name            = "GSI1"
-    hash_key        = "GSI1PK"
-    range_key       = "GSI1SK"
+    name            = "reportId"
+    hash_key        = "reportId"
     projection_type = "ALL"
   }
 
   dynamic "global_secondary_index" {
     for_each = var.with_team_gsi ? [1] : []
+
     content {
-      name            = "GSI2"
-      hash_key        = "GSI2PK"
-      range_key       = "GSI2SK"
+      name            = "team"
+      hash_key        = "team"
       projection_type = "ALL"
     }
+  }
+
+  point_in_time_recovery {
+    enabled = true
   }
 
   server_side_encryption {
@@ -31,7 +50,7 @@ resource "aws_dynamodb_table" "this" {
     kms_key_arn = var.kms_key_arn
   }
 
-  point_in_time_recovery { enabled = true }
-
-  tags = { Name = var.table_name }
+  tags = {
+    Name = var.table_name
+  }
 }

--- a/infra/terraform/modules/dynamodb/outputs.tf
+++ b/infra/terraform/modules/dynamodb/outputs.tf
@@ -1,2 +1,9 @@
-output "table_name" { value = aws_dynamodb_table.this.name }
-output "table_arn"  { value = aws_dynamodb_table.this.arn }
+output "table_name" {
+  description = "Name of the DynamoDB table"
+  value       = aws_dynamodb_table.this.name
+}
+
+output "table_arn" {
+  description = "ARN of the DynamoDB table"
+  value       = aws_dynamodb_table.this.arn
+}

--- a/infra/terraform/modules/dynamodb/variables.tf
+++ b/infra/terraform/modules/dynamodb/variables.tf
@@ -1,3 +1,15 @@
-variable "table_name" { type = string }
-variable "kms_key_arn" { type = string }
-variable "with_team_gsi" { type = bool default = true }
+variable "table_name" {
+  description = "Name of the DynamoDB table"
+  type        = string
+}
+
+variable "kms_key_arn" {
+  description = "ARN of the KMS key used to encrypt the table"
+  type        = string
+}
+
+variable "with_team_gsi" {
+  description = "Whether to enable the optional team global secondary index"
+  type        = bool
+  default     = true
+}

--- a/infra/terraform/modules/iam/variables.tf
+++ b/infra/terraform/modules/iam/variables.tf
@@ -1,4 +1,24 @@
-variable "name_prefix" { type = string }
-variable "ddb_table_arn" { type = string }
-variable "s3_reports_bucket_arn" { type = string }
-variable "s3_raw_bucket_arn" { type = string }
+variable "name_prefix" {
+  description = "Prefix used for naming IAM roles"
+  type        = string
+}
+
+variable "ddb_table_arn" {
+  description = "ARN of the DynamoDB table the workloads access"
+  type        = string
+}
+
+variable "s3_reports_bucket_arn" {
+  description = "ARN of the reports S3 bucket"
+  type        = string
+}
+
+variable "s3_raw_bucket_arn" {
+  description = "ARN of the raw uploads S3 bucket"
+  type        = string
+}
+
+variable "kms_key_arn" {
+  description = "ARN of the KMS CMK backing S3 SSE-KMS"
+  type        = string
+}

--- a/infra/terraform/modules/s3/main.tf
+++ b/infra/terraform/modules/s3/main.tf
@@ -1,34 +1,53 @@
-// KMS Key for S3 SSE
 resource "aws_kms_key" "s3" {
-  description = "${var.name_prefix} S3 KMS key"
+  description             = "KMS key for ${var.name_prefix} S3 buckets"
   deletion_window_in_days = 7
-}
+  enable_key_rotation     = true
 
-locals {
-  buckets = {
-    raw     = var.raw_bucket_name
-    reports = var.report_bucket_name
+  tags = {
+    Name = "${var.name_prefix}-s3-kms"
   }
 }
 
-// Create two buckets: raw uploads + report texts
-resource "aws_s3_bucket" "b" {
-  for_each = local.buckets
-  bucket   = each.value
+resource "aws_kms_alias" "s3" {
+  name          = "alias/${var.name_prefix}-s3"
+  target_key_id = aws_kms_key.s3.id
 }
 
-resource "aws_s3_bucket_public_access_block" "b" {
-  for_each = aws_s3_bucket.b
-  bucket                  = each.value.id
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
+resource "aws_s3_bucket" "raw" {
+  bucket = var.raw_bucket_name
+
+  tags = {
+    Name = "${var.name_prefix}-raw"
+  }
 }
 
-resource "aws_s3_bucket_server_side_encryption_configuration" "sse" {
-  for_each = aws_s3_bucket.b
-  bucket   = each.value.id
+resource "aws_s3_bucket" "reports" {
+  bucket = var.report_bucket_name
+
+  tags = {
+    Name = "${var.name_prefix}-reports"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "raw" {
+  bucket = aws_s3_bucket.raw.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "reports" {
+  bucket = aws_s3_bucket.reports.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "raw" {
+  bucket = aws_s3_bucket.raw.id
+
   rule {
     apply_server_side_encryption_by_default {
       kms_master_key_id = aws_kms_key.s3.arn
@@ -37,27 +56,87 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "sse" {
   }
 }
 
-resource "aws_s3_bucket_versioning" "v" {
-  for_each = aws_s3_bucket.b
-  bucket   = each.value.id
-  versioning_configuration { status = "Enabled" }
+resource "aws_s3_bucket_server_side_encryption_configuration" "reports" {
+  bucket = aws_s3_bucket.reports.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.s3.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
 }
 
-resource "aws_s3_bucket_policy" "tls_only" {
-  for_each = aws_s3_bucket.b
-  bucket   = each.value.id
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [{
-      Sid = "DenyInsecureTransport",
-      Effect = "Deny",
-      Principal = "*",
-      Action = "s3:*",
-      Resource = [
-        each.value.arn,
-        "${each.value.arn}/*"
-      ],
-      Condition = { Bool = { "aws:SecureTransport" = "false" } }
-    }]
-  })
+resource "aws_s3_bucket_public_access_block" "raw" {
+  bucket                  = aws_s3_bucket.raw.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "reports" {
+  bucket                  = aws_s3_bucket.reports.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+data "aws_iam_policy_document" "tls_only_raw" {
+  statement {
+    sid     = "ForceTLS"
+    effect  = "Deny"
+    actions = ["s3:*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      aws_s3_bucket.raw.arn,
+      "${aws_s3_bucket.raw.arn}/*"
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "tls_only_reports" {
+  statement {
+    sid     = "ForceTLS"
+    effect  = "Deny"
+    actions = ["s3:*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      aws_s3_bucket.reports.arn,
+      "${aws_s3_bucket.reports.arn}/*"
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "raw" {
+  bucket = aws_s3_bucket.raw.id
+  policy = data.aws_iam_policy_document.tls_only_raw.json
+}
+
+resource "aws_s3_bucket_policy" "reports" {
+  bucket = aws_s3_bucket.reports.id
+  policy = data.aws_iam_policy_document.tls_only_reports.json
 }

--- a/infra/terraform/modules/s3/outputs.tf
+++ b/infra/terraform/modules/s3/outputs.tf
@@ -1,3 +1,14 @@
-output "kms_key_arn" { value = aws_kms_key.s3.arn }
-output "raw_bucket" { value = aws_s3_bucket.b["raw"].id }
-output "reports_bucket" { value = aws_s3_bucket.b["reports"].id }
+output "raw_bucket" {
+  description = "Raw uploads bucket name"
+  value       = aws_s3_bucket.raw.id
+}
+
+output "reports_bucket" {
+  description = "Reports bucket name"
+  value       = aws_s3_bucket.reports.id
+}
+
+output "kms_key_arn" {
+  description = "ARN of the KMS key used for the buckets"
+  value       = aws_kms_key.s3.arn
+}

--- a/infra/terraform/modules/s3/variables.tf
+++ b/infra/terraform/modules/s3/variables.tf
@@ -1,3 +1,14 @@
-variable "name_prefix" { type = string }
-variable "raw_bucket_name" { type = string }
-variable "report_bucket_name" { type = string }
+variable "name_prefix" {
+  description = "Prefix used for naming the S3 resources"
+  type        = string
+}
+
+variable "raw_bucket_name" {
+  description = "Name of the raw uploads bucket"
+  type        = string
+}
+
+variable "report_bucket_name" {
+  description = "Name of the reports bucket"
+  type        = string
+}

--- a/infra/terraform/modules/vpc/main.tf
+++ b/infra/terraform/modules/vpc/main.tf
@@ -38,7 +38,10 @@ resource "aws_nat_gateway" "nat" {
 
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.this.id
-  route { cidr_block = "0.0.0.0/0" gateway_id = aws_internet_gateway.igw.id }
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
   tags = { Name = "${var.name}-public-rt" }
 }
 
@@ -50,7 +53,10 @@ resource "aws_route_table_association" "public" {
 
 resource "aws_route_table" "private" {
   vpc_id = aws_vpc.this.id
-  route { cidr_block = "0.0.0.0/0" nat_gateway_id = aws_nat_gateway.nat.id }
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat.id
+  }
   tags = { Name = "${var.name}-private-rt" }
 }
 

--- a/infra/terraform/modules/vpc/outputs.tf
+++ b/infra/terraform/modules/vpc/outputs.tf
@@ -1,3 +1,14 @@
-output "vpc_id" { value = aws_vpc.this.id }
-output "public_subnet_ids" { value = [for s in aws_subnet.public : s.id] }
-output "private_subnet_ids" { value = [for s in aws_subnet.private : s.id] }
+output "vpc_id" {
+  description = "ID of the created VPC"
+  value       = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = [for subnet in aws_subnet.public : subnet.id]
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets"
+  value       = [for subnet in aws_subnet.private : subnet.id]
+}

--- a/infra/terraform/modules/vpc/variables.tf
+++ b/infra/terraform/modules/vpc/variables.tf
@@ -1,5 +1,24 @@
-variable "name" { type = string }
-variable "cidr_block" { type = string }
-variable "azs" { type = list(string) }
-variable "public_subnet_cidrs" { type = list(string) }
-variable "private_subnet_cidrs" { type = list(string) }
+variable "name" {
+  description = "Base name used for tagging VPC resources"
+  type        = string
+}
+
+variable "cidr_block" {
+  description = "CIDR block for the VPC"
+  type        = string
+}
+
+variable "azs" {
+  description = "Availability zones to use for subnets"
+  type        = list(string)
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets"
+  type        = list(string)
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets"
+  type        = list(string)
+}


### PR DESCRIPTION
Supersedes closed PR #5.

- Add CMK key policy permitting DynamoDB service (scoped via encryption context).
- Grant kms:Encrypt/Decrypt/GenerateDataKey/... to ECS task & Lambda roles for SSE-KMS buckets.
- Fix VPC EIP deprecation (domain="vpc") and multiline HCL blocks.
- Ensure .terraform/ is ignored and large blobs removed from history.
