### PR TITLE
Add Spring Boot players API skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,3 +8,18 @@ jobs:
     steps:
       - name: Placeholder step
         run: echo "Configure CI workflow"
+
+  build-java:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/players-api
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+      - name: Build
+        run: ./mvnw -q -e -DskipTests package

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,3 @@
+#!/bin/sh
+DIR="$(dirname "$0")"
+exec "$DIR/services/players-api/mvnw" "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+SET DIR=%~dp0
+CALL "%DIR%services\players-api\mvnw.cmd" %*

--- a/services/players-api/.mvn/wrapper/maven-wrapper.properties
+++ b/services/players-api/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,2 @@
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/services/players-api/Dockerfile
+++ b/services/players-api/Dockerfile
@@ -1,4 +1,15 @@
-# Placeholder Dockerfile for the Players API service
-FROM eclipse-temurin:17-jre-alpine
+# ====== Build stage ======
+FROM maven:3.9.9-eclipse-temurin-21 AS build
 WORKDIR /app
-CMD ["java", "-jar", "players-api.jar"]
+COPY pom.xml .
+RUN mvn -q -e -DskipTests dependency:go-offline
+COPY src ./src
+RUN mvn -q -e -DskipTests package
+
+# ====== Runtime stage ======
+FROM eclipse-temurin:21-jre
+ENV JAVA_OPTS=""
+WORKDIR /opt/app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["sh","-c","java $JAVA_OPTS -jar app.jar"]

--- a/services/players-api/mvnw
+++ b/services/players-api/mvnw
@@ -19,41 +19,105 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.2.0
+# Apache Maven Wrapper startup script, version 3.2.0
 # ----------------------------------------------------------------------------
 
-set -eu
+if [ -z "$MAVEN_SKIP_RC" ] ; then
 
-MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$(cd "$(dirname "$0")"; pwd -P)"}
-BASE_DIR="$MAVEN_PROJECTBASEDIR"
-WRAPPER_JAR="$BASE_DIR/.mvn/wrapper/maven-wrapper.jar"
-WRAPPER_LAUNCHER="org.apache.maven.wrapper.MavenWrapperMain"
+  if [ -f /usr/local/etc/mavenrc ] ; then
+    . /usr/local/etc/mavenrc
+  fi
 
-if [ ! -r "$WRAPPER_JAR" ]; then
-  mkdir -p "$(dirname "$WRAPPER_JAR")"
+  if [ -f "$HOME/.mavenrc" ] ; then
+    . "$HOME/.mavenrc"
+  fi
+
+fi
+
+cygwin=false
+mingw=false
+case "`uname`" in
+  CYGWIN*) cygwin=true ;;
+  MINGW*) mingw=true ;;
+  MSYS*) mingw=true ;;
+  NONSTOP*) nonstop=true ;;
+  *) ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -x "/usr/libexec/java_home" ] ; then
+    JAVA_HOME="`/usr/libexec/java_home`"
+  fi
+fi
+
+if [ -z "$JAVA_HOME" ] ; then
+  javaExecutable="`which java`"
+  if [ -n "$javaExecutable" ] && ! [ "`expr \"$javaExecutable\" : '\([^ ]*\)'`" = "no" ] ; then
+    JAVA_HOME="`dirname \"$javaExecutable\"`/.."
+  fi
+fi
+
+if [ -z "$JAVA_HOME" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." >&2
+  echo "  We cannot execute java" >&2
+  exit 1
+fi
+
+JAVA_CMD="$JAVA_HOME/bin/java"
+if [ ! -x "$JAVA_CMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." >&2
+  echo "  We cannot execute $JAVA_CMD" >&2
+  exit 1
+fi
+
+BASE_DIR="`dirname "$0"`"
+MAVEN_PROJECTBASEDIR="`cd "$BASE_DIR" ; pwd`"
+
+WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+WRAPPER_JAR="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar"
+if [ ! -f "$WRAPPER_JAR" ]; then
+  if [ "$MVNW_VERBOSE" = true ]; then
+    echo "Couldn't find $WRAPPER_JAR, downloading it ..."
+  fi
   DOWNLOAD_URL="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
-  if command -v curl >/dev/null 2>&1; then
-    curl -sSfL "$DOWNLOAD_URL" -o "$WRAPPER_JAR"
-  elif command -v wget >/dev/null 2>&1; then
-    wget -q -O "$WRAPPER_JAR" "$DOWNLOAD_URL"
+  DOWNLOAD_SUCCESS=false
+  if command -v curl > /dev/null 2>&1; then
+    if curl -fsSL "$DOWNLOAD_URL" -o "$WRAPPER_JAR"; then
+      DOWNLOAD_SUCCESS=true
+    fi
+  elif command -v wget > /dev/null 2>&1; then
+    if wget -q "$DOWNLOAD_URL" -O "$WRAPPER_JAR"; then
+      DOWNLOAD_SUCCESS=true
+    fi
   else
     echo "Error: Please install curl or wget to download the Maven Wrapper." >&2
+  fi
+
+  if [ "$DOWNLOAD_SUCCESS" != true ]; then
+    if command -v mvn > /dev/null 2>&1; then
+      if [ "$MVNW_VERBOSE" = true ]; then
+        echo "Falling back to system Maven (mvn) because the wrapper JAR could not be downloaded." >&2
+      fi
+      exec mvn -f "$MAVEN_PROJECTBASEDIR/pom.xml" -Dmaven.multiModuleProjectDirectory="$MAVEN_PROJECTBASEDIR" "$@"
+    fi
+    echo "Error: Failed to download $WRAPPER_JAR and no system Maven (mvn) command is available." >&2
     exit 1
   fi
 fi
 
-if [ -n "${JAVA_HOME:-}" ]; then
-  JAVA_EXEC="$JAVA_HOME/bin/java"
-  if [ ! -x "$JAVA_EXEC" ]; then
-    echo "Error: JAVA_HOME is set to an invalid directory: $JAVA_HOME" >&2
-    exit 1
-  fi
-else
-  JAVA_EXEC=$(command -v java || true)
-  if [ -z "$JAVA_EXEC" ]; then
-    echo "Error: JAVA_HOME is not set and no 'java' command could be found." >&2
-    exit 1
-  fi
+if [ "$cygwin" = true ] || [ "$mingw" = true ] ; then
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`cygpath --path --windows "$JAVA_HOME"`"
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH="`cygpath --path --windows "$CLASSPATH"`"
+  [ -n "$MAVEN_PROJECTBASEDIR" ] &&
+    MAVEN_PROJECTBASEDIR="`cygpath --path --windows "$MAVEN_PROJECTBASEDIR"`"
 fi
 
-exec "$JAVA_EXEC" -classpath "$WRAPPER_JAR" $WRAPPER_LAUNCHER "$@"
+WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+exec "$JAVA_CMD" \
+  -classpath "$WRAPPER_JAR" \
+  -Dmaven.multiModuleProjectDirectory="$MAVEN_PROJECTBASEDIR" \
+  $WRAPPER_LAUNCHER "$@"

--- a/services/players-api/mvnw
+++ b/services/players-api/mvnw
@@ -1,0 +1,59 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.2.0
+# ----------------------------------------------------------------------------
+
+set -eu
+
+MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$(cd "$(dirname "$0")"; pwd -P)"}
+BASE_DIR="$MAVEN_PROJECTBASEDIR"
+WRAPPER_JAR="$BASE_DIR/.mvn/wrapper/maven-wrapper.jar"
+WRAPPER_LAUNCHER="org.apache.maven.wrapper.MavenWrapperMain"
+
+if [ ! -r "$WRAPPER_JAR" ]; then
+  mkdir -p "$(dirname "$WRAPPER_JAR")"
+  DOWNLOAD_URL="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+  if command -v curl >/dev/null 2>&1; then
+    curl -sSfL "$DOWNLOAD_URL" -o "$WRAPPER_JAR"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q -O "$WRAPPER_JAR" "$DOWNLOAD_URL"
+  else
+    echo "Error: Please install curl or wget to download the Maven Wrapper." >&2
+    exit 1
+  fi
+fi
+
+if [ -n "${JAVA_HOME:-}" ]; then
+  JAVA_EXEC="$JAVA_HOME/bin/java"
+  if [ ! -x "$JAVA_EXEC" ]; then
+    echo "Error: JAVA_HOME is set to an invalid directory: $JAVA_HOME" >&2
+    exit 1
+  fi
+else
+  JAVA_EXEC=$(command -v java || true)
+  if [ -z "$JAVA_EXEC" ]; then
+    echo "Error: JAVA_HOME is not set and no 'java' command could be found." >&2
+    exit 1
+  fi
+fi
+
+exec "$JAVA_EXEC" -classpath "$WRAPPER_JAR" $WRAPPER_LAUNCHER "$@"

--- a/services/players-api/mvnw.cmd
+++ b/services/players-api/mvnw.cmd
@@ -1,0 +1,47 @@
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    https://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.2.0
+@REM ----------------------------------------------------------------------------
+
+@SETLOCAL ENABLEDELAYEDEXPANSION
+
+set "DIR=%~dp0"
+if "%DIR%" == "" set DIR=.
+set "BASE_DIR=%DIR%"
+
+set "WRAPPER_JAR=%BASE_DIR%\.mvn\wrapper\maven-wrapper.jar"
+set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+if exist "%WRAPPER_JAR%" goto execute
+
+if exist "%BASE_DIR%\.mvn\wrapper" goto download
+mkdir "%BASE_DIR%\.mvn\wrapper"
+
+:download
+set DOWNLOAD_URL=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+if exist "%BASE_DIR%\.mvn\wrapper\maven-wrapper.jar" goto execute
+powershell -Command "Invoke-WebRequest -Uri %DOWNLOAD_URL% -OutFile '%WRAPPER_JAR%'" || (
+  echo Error: Please install PowerShell 3 or newer to download the Maven Wrapper.
+  exit /b 1
+)
+
+:execute
+"%JAVA_HOME%\bin\java" -classpath "%WRAPPER_JAR%" %WRAPPER_LAUNCHER% %*

--- a/services/players-api/mvnw.cmd
+++ b/services/players-api/mvnw.cmd
@@ -21,27 +21,62 @@
 @REM Apache Maven Wrapper startup batch script, version 3.2.0
 @REM ----------------------------------------------------------------------------
 
-@SETLOCAL ENABLEDELAYEDEXPANSION
+@echo off
+setlocal
 
 set "DIR=%~dp0"
-if "%DIR%" == "" set DIR=.
-set "BASE_DIR=%DIR%"
+if "%DIR%"=="" set DIR=.
+set "DIR=%DIR:~0,-1%"
+set "MAVEN_PROJECTBASEDIR=%DIR%"
 
-set "WRAPPER_JAR=%BASE_DIR%\.mvn\wrapper\maven-wrapper.jar"
+set "WRAPPER_JAR=%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+if exist "%MAVEN_PROJECTBASEDIR%\.mvn\maven.config" (
+  set /p MAVEN_CONFIG=<"%MAVEN_PROJECTBASEDIR%\.mvn\maven.config"
+)
 
 if exist "%WRAPPER_JAR%" goto execute
 
-if exist "%BASE_DIR%\.mvn\wrapper" goto download
-mkdir "%BASE_DIR%\.mvn\wrapper"
+if exist "%MAVEN_PROJECTBASEDIR%\.mvn\wrapper" goto download
+mkdir "%MAVEN_PROJECTBASEDIR%\.mvn\wrapper"
 
 :download
 set DOWNLOAD_URL=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
-if exist "%BASE_DIR%\.mvn\wrapper\maven-wrapper.jar" goto execute
-powershell -Command "Invoke-WebRequest -Uri %DOWNLOAD_URL% -OutFile '%WRAPPER_JAR%'" || (
-  echo Error: Please install PowerShell 3 or newer to download the Maven Wrapper.
-  exit /b 1
+if exist "%WRAPPER_JAR%" goto execute
+powershell -Command "Invoke-WebRequest -Uri %DOWNLOAD_URL% -OutFile '%WRAPPER_JAR:"=%'"" >NUL 2>&1
+if exist "%WRAPPER_JAR%" goto execute
+if defined MVNW_VERBOSE echo Failed to download %WRAPPER_JAR% from %DOWNLOAD_URL%, falling back to system Maven if available. >&2
+
+for %%I in (mvn.cmd mvn.bat mvn.exe mvn) do (
+  where %%I >NUL 2>&1 && (set "MVN_CMD=%%I" & goto run_mvn)
 )
+if defined MAVEN_HOME if exist "%MAVEN_HOME%\bin\mvn.cmd" set "MVN_CMD=%MAVEN_HOME%\bin\mvn.cmd"
+if defined MAVEN_HOME if exist "%MAVEN_HOME%\bin\mvn.bat" set "MVN_CMD=%MAVEN_HOME%\bin\mvn.bat"
+if defined MAVEN_HOME if exist "%MAVEN_HOME%\bin\mvn.exe" set "MVN_CMD=%MAVEN_HOME%\bin\mvn.exe"
+if defined MVN_CMD goto run_mvn
+
+echo Error: Failed to download %WRAPPER_JAR% and no system Maven (mvn) command is available. >&2
+exit /b 1
 
 :execute
-"%JAVA_HOME%\bin\java" -classpath "%WRAPPER_JAR%" %WRAPPER_LAUNCHER% %*
+set "JAVA_EXE=%JAVA_HOME%\bin\java.exe"
+if defined JAVA_HOME if exist "%JAVA_EXE%" goto run_wrapper
+
+set "JAVA_EXE=java"
+"%JAVA_EXE%" -version >NUL 2>&1
+if %ERRORLEVEL% equ 0 goto run_wrapper
+
+echo Error: JAVA_HOME is not defined correctly. >&2
+echo   We cannot execute java >&2
+exit /b 1
+
+:run_wrapper
+"%JAVA_EXE%" -classpath "%WRAPPER_JAR%" -Dmaven.multiModuleProjectDirectory="%MAVEN_PROJECTBASEDIR%" %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
+endlocal
+exit /b %ERRORLEVEL%
+
+:run_mvn
+"%MVN_CMD%" -f "%MAVEN_PROJECTBASEDIR%\pom.xml" -Dmaven.multiModuleProjectDirectory="%MAVEN_PROJECTBASEDIR%" %*
+endlocal
+exit /b %ERRORLEVEL%

--- a/services/players-api/pom.xml
+++ b/services/players-api/pom.xml
@@ -1,9 +1,95 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <groupId>com.vsm</groupId>
   <artifactId>players-api</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-  <description>Placeholder Maven configuration for the Players API</description>
+  <version>0.1.0-SNAPSHOT</version>
+  <name>players-api</name>
+  <description>Volleyball Stats Messenger - Spring Boot API</description>
+
+  <properties>
+    <java.version>21</java.version>
+    <spring-boot.version>3.3.3</spring-boot.version>
+    <springdoc.version>2.6.0</springdoc.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- Web + Validation -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+
+    <!-- Security: JWT Resource Server -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+    </dependency>
+
+    <!-- Actuator (health/metrics) -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <!-- OpenAPI/Swagger -->
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>${springdoc.version}</version>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <!-- Spring Boot plugin (build/run) -->
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <image>
+            <builder>paketobuildpacks/builder-jammy-base</builder>
+          </image>
+        </configuration>
+      </plugin>
+
+      <!-- Compiler to Java 21 -->
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <release>21</release>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
 </project>

--- a/services/players-api/src/main/java/com/vsm/api/PlayersApiApplication.java
+++ b/services/players-api/src/main/java/com/vsm/api/PlayersApiApplication.java
@@ -1,7 +1,11 @@
 package com.vsm.api;
 
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
 public class PlayersApiApplication {
     public static void main(String[] args) {
-        // TODO: bootstrap Spring application
+        SpringApplication.run(PlayersApiApplication.class, args);
     }
 }

--- a/services/players-api/src/main/java/com/vsm/api/config/SecurityConfig.java
+++ b/services/players-api/src/main/java/com/vsm/api/config/SecurityConfig.java
@@ -1,5 +1,46 @@
 package com.vsm.api.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Two modes:
+ * 1) Normal (auth enabled): JWT required for /api/**
+ * 2) Local profile (spring.profiles.active=local): auth disabled, everything permitted (dev convenience)
+ */
+@Configuration
 public class SecurityConfig {
-    // TODO: configure security
+
+    @Bean
+    @Profile("!local")
+    SecurityFilterChain api(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(reg -> reg
+                .requestMatchers(
+                    "/actuator/health",
+                    "/v3/api-docs/**",
+                    "/swagger-ui.html", "/swagger-ui/**"
+                ).permitAll()
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                .requestMatchers("/api/**").authenticated()
+                .anyRequest().permitAll()
+            )
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+        return http.build();
+    }
+
+    @Bean
+    @Profile("local")
+    SecurityFilterChain localAllOpen(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(reg -> reg.anyRequest().permitAll());
+        return http.build();
+    }
 }

--- a/services/players-api/src/main/java/com/vsm/api/model/ReportRequest.java
+++ b/services/players-api/src/main/java/com/vsm/api/model/ReportRequest.java
@@ -1,0 +1,28 @@
+package com.vsm.api.model;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.Map;
+
+public class ReportRequest {
+
+    @NotBlank
+    private String playerId;
+
+    @Email
+    @NotBlank
+    private String playerEmail;
+
+    @NotEmpty
+    private Map<@NotBlank String, @NotBlank String> categories;
+
+    public String getPlayerId() { return playerId; }
+    public void setPlayerId(String playerId) { this.playerId = playerId; }
+
+    public String getPlayerEmail() { return playerEmail; }
+    public void setPlayerEmail(String playerEmail) { this.playerEmail = playerEmail; }
+
+    public Map<String, String> getCategories() { return categories; }
+    public void setCategories(Map<String, String> categories) { this.categories = categories; }
+}

--- a/services/players-api/src/main/java/com/vsm/api/web/CoachReportsController.java
+++ b/services/players-api/src/main/java/com/vsm/api/web/CoachReportsController.java
@@ -1,0 +1,30 @@
+package com.vsm.api.web;
+
+import com.vsm.api.model.ReportRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/coach/reports")
+@Tag(name = "Coach Reports")
+public class CoachReportsController {
+
+    @PostMapping
+    @Operation(summary = "Create and send a report (stub)", description = "Validates input; returns a fake reportId for now.")
+    public ResponseEntity<?> createReport(@Valid @RequestBody ReportRequest req) {
+        // Day 3: just validate and return a fake ID
+        String reportId = UUID.randomUUID().toString();
+        return ResponseEntity.accepted().body(Map.of(
+            "reportId", reportId,
+            "status", "QUEUED",
+            "at", Instant.now().toString()
+        ));
+    }
+}

--- a/services/players-api/src/main/java/com/vsm/api/web/HealthController.java
+++ b/services/players-api/src/main/java/com/vsm/api/web/HealthController.java
@@ -1,5 +1,15 @@
 package com.vsm.api.web;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
 public class HealthController {
-    // TODO: implement health endpoints
+
+    @GetMapping("/health")
+    public Map<String, Object> health() {
+        return Map.of("status", "UP");
+    }
 }

--- a/services/players-api/src/main/resources/application-local.yml
+++ b/services/players-api/src/main/resources/application-local.yml
@@ -1,0 +1,7 @@
+# Local profile: disable auth (see SecurityConfig @Profile("local"))
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ""

--- a/services/players-api/src/main/resources/application.yml
+++ b/services/players-api/src/main/resources/application.yml
@@ -1,1 +1,29 @@
-# Placeholder Spring configuration
+server:
+  port: 8080
+
+spring:
+  application:
+    name: players-api
+
+  # Default profile: "dev" (auth enabled). Set issuer via env var COGNITO_ISSUER_URI
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${COGNITO_ISSUER_URI:}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html


### PR DESCRIPTION
## Summary
- set up the players-api module with Spring Boot 3.3 dependencies, validation, actuator, and OpenAPI support
- implement entrypoint, security configuration, stub coach report endpoint, and health check with profile-based configuration
- add Maven wrapper, Dockerfile, and CI workflow job to build the players API service

## Testing
- ./mvnw -q -e -DskipTests package *(fails: 403 while downloading from Maven Central in this environment)*
