### PR TITLE
Add JUnit tests for players API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
         with:
           distribution: temurin
           java-version: "21"
-      - name: Build
-        run: ./mvnw -q -e -DskipTests package
+      - name: Build & Test
+        run: ./mvnw -q -e verify

--- a/services/players-api/src/test/java/com/vsm/api/PlayersApiApplicationTests.java
+++ b/services/players-api/src/test/java/com/vsm/api/PlayersApiApplicationTests.java
@@ -1,0 +1,15 @@
+package com.vsm.api;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("local") // disable auth for test boot
+class PlayersApiApplicationTests {
+
+    @Test
+    void contextLoads() {
+        // if the app context fails to start, this test fails
+    }
+}

--- a/services/players-api/src/test/java/com/vsm/api/web/CoachReportsControllerTest.java
+++ b/services/players-api/src/test/java/com/vsm/api/web/CoachReportsControllerTest.java
@@ -1,0 +1,51 @@
+package com.vsm.api.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("local") // disable auth in tests
+class CoachReportsControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Test
+    void createReport_returns202_forValidPayload() throws Exception {
+        String body = """
+          {
+            \"playerId\": \"p123\",
+            \"playerEmail\": \"player@example.com\",
+            \"categories\": { \"Aces\": \"5\", \"Blocks\": \"3\" }
+          }
+        """;
+        mvc.perform(post("/api/coach/reports")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+           .andExpect(status().isAccepted());
+    }
+
+    @Test
+    void createReport_returns400_forInvalidEmail() throws Exception {
+        String body = """
+          {
+            \"playerId\": \"p123\",
+            \"playerEmail\": \"not-an-email\",
+            \"categories\": { \"Aces\": \"5\" }
+          }
+        """;
+        mvc.perform(post("/api/coach/reports")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+           .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Summary
- add a Spring Boot context loading test that uses the local profile
- add controller tests covering valid and invalid coach report submissions
- update CI workflow to run Maven verify so tests execute in automation

## Testing
- ./mvnw -q test

------
https://chatgpt.com/codex/tasks/task_e_68db71f35e34832f930161c919a8c602