### PR TITLE
feat(frontend): scaffold Angular app with auth shell

### DIFF
--- a/frontend/.browserslistrc
+++ b/frontend/.browserslistrc
@@ -1,0 +1,10 @@
+# This file is used by the build system to adjust CSS and JS output to support the specified browsers.
+# For additional information regarding the format and rule options, please see:
+# https://github.com/browserslist/browserslist#queries
+
+last 2 Chrome versions
+last 1 Firefox version
+last 2 Edge major versions
+last 2 Safari major versions
+Firefox ESR
+not ie <= 11

--- a/frontend/.editorconfig
+++ b/frontend/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,34 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# compiled output
+/dist
+/tmp
+/out-tsc
+
+# dependencies
+/node_modules
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# misc
+/.angular/cache
+/.sass-cache
+/connect.lock
+coverage
+npm-debug.log
+.yarn-integrity
+.env

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,15 @@
-# Frontend
+# VSM Portal
 
-Details about the frontend application will be documented here.
+This project was generated to host the Volleyball Stats Messenger (VSM) front-end. It uses Angular with SCSS styling and OAuth authentication via Amazon Cognito.
+
+## Development server
+
+Run `npm start` to start the dev server. Navigate to `http://localhost:4200/`. The app automatically reloads if you change any of the source files.
+
+## Build
+
+Run `npm run build` to build the project. The build artifacts are stored in the `dist/` directory.
+
+## Running unit tests
+
+Run `npm test` to execute the unit tests via [Karma](https://karma-runner.github.io) and [Jasmine](https://jasmine.github.io).

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "vsm-portal": {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:application",
+          "options": {
+            "outputPath": "dist/vsm-portal",
+            "index": "src/index.html",
+            "browser": "src/main.ts",
+            "polyfills": ["zone.js"],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
+              "budgets": [
+                { "type": "initial", "maximumWarning": "500kb", "maximumError": "1mb" },
+                { "type": "anyComponentStyle", "maximumWarning": "2kb", "maximumError": "4kb" }
+              ],
+              "outputHashing": "all"
+            },
+            "development": {
+              "optimization": false,
+              "sourceMap": true,
+              "extractLicenses": false
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "configurations": {
+            "production": {
+              "buildTarget": "vsm-portal:build:production"
+            },
+            "development": {
+              "buildTarget": "vsm-portal:build:development"
+            }
+          },
+          "defaultConfiguration": "development"
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma"
+        }
+      }
+    }
+  },
+  "defaultProject": "vsm-portal",
+  "cli": {
+    "analytics": false
+  }
+}

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -1,0 +1,35 @@
+const { join } = require('path');
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {
+        clearContext: false
+      }
+    },
+    coverageReporter: {
+      dir: join(__dirname, './coverage/vsm-portal'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' }
+      ]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,40 @@
 {
-  "name": "stat-tracker-frontend",
+  "name": "vsm-portal",
   "version": "0.0.0",
   "private": true,
-  "description": "Placeholder package configuration for the frontend application"
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "watch": "ng build --watch --configuration development",
+    "test": "ng test"
+  },
+  "dependencies": {
+    "@angular/animations": "^18.2.6",
+    "@angular/common": "^18.2.6",
+    "@angular/compiler": "^18.2.6",
+    "@angular/core": "^18.2.6",
+    "@angular/forms": "^18.2.6",
+    "@angular/platform-browser": "^18.2.6",
+    "@angular/platform-browser-dynamic": "^18.2.6",
+    "@angular/router": "^18.2.6",
+    "angular-oauth2-oidc": "^17.0.2",
+    "jwt-decode": "^4.0.0",
+    "rxjs": "~7.8.1",
+    "tslib": "^2.6.2",
+    "zone.js": "~0.14.10"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^18.2.6",
+    "@angular/cli": "^18.2.6",
+    "@angular/compiler-cli": "^18.2.6",
+    "@types/jasmine": "~5.1.0",
+    "jasmine-core": "~5.2.0",
+    "karma": "~6.4.0",
+    "karma-chrome-launcher": "~3.2.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "typescript": "~5.5.4"
+  }
 }

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { HomeComponent } from './pages/home.component';
+import { SendStatsComponent } from './pages/send-stats.component';
+import { AuthCallbackComponent } from './pages/auth-callback.component';
+import { AuthGuard } from './auth/auth.guard';
+
+const routes: Routes = [
+  { path: '', component: HomeComponent },
+  { path: 'send', component: SendStatsComponent, canActivate: [AuthGuard] },
+  { path: 'auth/callback', component: AuthCallbackComponent },
+  { path: '**', redirectTo: '' }
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes, { bindToComponentInputs: true })],
+  exports: [RouterModule],
+})
+export class AppRoutingModule {}

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,0 +1,4 @@
+<app-navbar></app-navbar>
+<main class="container">
+  <router-outlet></router-outlet>
+</main>

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -1,0 +1,8 @@
+:host {
+  display: block;
+}
+
+main.container {
+  margin: 0 auto;
+  max-width: 960px;
+}

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { AppComponent } from './app.component';
+import { NavbarComponent } from './shared/navbar.component';
+
+describe('AppComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, NavbarComponent],
+      declarations: [AppComponent],
+    }).compileComponents();
+  });
+
+  it('should create the app', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    expect(app).toBeTruthy();
+  });
+});

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -4,6 +4,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 import { NavbarComponent } from './shared/navbar.component';
 import { AuthService } from './auth/auth.service';
+import { OAuthService } from 'angular-oauth2-oidc';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
@@ -13,10 +14,24 @@ describe('AppComponent', () => {
       logout: () => void 0,
     };
 
+    const oauthServiceStub: Partial<OAuthService> = {
+      configure: () => void 0,
+      setupAutomaticSilentRefresh: () => void 0,
+      loadDiscoveryDocumentAndTryLogin: () => Promise.resolve(),
+      hasValidAccessToken: () => false,
+      hasValidIdToken: () => false,
+      getAccessToken: () => null,
+      initLoginFlow: () => void 0,
+      logOut: () => void 0,
+    };
+
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule, NavbarComponent],
       declarations: [AppComponent],
-      providers: [{ provide: AuthService, useValue: authServiceStub }],
+      providers: [
+        { provide: AuthService, useValue: authServiceStub },
+        { provide: OAuthService, useValue: oauthServiceStub },
+      ],
     }).compileComponents();
   });
 

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -3,12 +3,20 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { AppComponent } from './app.component';
 import { NavbarComponent } from './shared/navbar.component';
+import { AuthService } from './auth/auth.service';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
+    const authServiceStub: Partial<AuthService> = {
+      isLoggedIn: () => false,
+      login: () => void 0,
+      logout: () => void 0,
+    };
+
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule, NavbarComponent],
       declarations: [AppComponent],
+      providers: [{ provide: AuthService, useValue: authServiceStub }],
     }).compileComponents();
   });
 

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss']
+})
+export class AppComponent {}

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,0 +1,22 @@
+import { APP_INITIALIZER, NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { OAuthModule } from 'angular-oauth2-oidc';
+import { AppRoutingModule } from './app-routing.module';
+import { AppComponent } from './app.component';
+import { AuthService } from './auth/auth.service';
+import { JwtInterceptor } from './auth/jwt.interceptor';
+import { NavbarComponent } from './shared/navbar.component';
+
+export function initAuth(auth: AuthService) { return () => auth.init(); }
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule, HttpClientModule, OAuthModule.forRoot(), AppRoutingModule, NavbarComponent],
+  providers: [
+    { provide: APP_INITIALIZER, useFactory: initAuth, deps: [AuthService], multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true }
+  ],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}

--- a/frontend/src/app/auth/auth.guard.ts
+++ b/frontend/src/app/auth/auth.guard.ts
@@ -1,3 +1,13 @@
-export function authGuardPlaceholder(): void {
-  // TODO: implement authentication guard logic
+import { Injectable } from '@angular/core';
+import { CanActivate, UrlTree } from '@angular/router';
+import { AuthService } from './auth.service';
+
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate {
+  constructor(private auth: AuthService) {}
+  canActivate(): boolean | UrlTree {
+    if (this.auth.isLoggedIn()) return true;
+    this.auth.login();
+    return false;
+  }
 }

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { OAuthService, AuthConfig } from 'angular-oauth2-oidc';
+import { environment } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private authConfig: AuthConfig = {
+    issuer: `https://cognito-idp.${environment.cognito.region}.amazonaws.com/${environment.cognito.userPoolId}`,
+    clientId: environment.cognito.clientId,
+    redirectUri: environment.cognito.redirectUri,
+    postLogoutRedirectUri: environment.cognito.postLogoutRedirectUri,
+    responseType: 'code',
+    scope: environment.cognito.scope,
+    showDebugInformation: false,
+    timeoutFactor: 0.75,
+    useSilentRefresh: false,
+    disablePKCE: false,
+  };
+
+  constructor(private oauth: OAuthService) {}
+
+  async init(): Promise<void> {
+    this.oauth.configure(this.authConfig);
+    this.oauth.setupAutomaticSilentRefresh();
+    await this.oauth.loadDiscoveryDocumentAndTryLogin();
+  }
+
+  login(): void { this.oauth.initLoginFlow(); }
+  logout(): void { this.oauth.logOut(); }
+
+  get accessToken(): string | null {
+    return this.oauth.hasValidAccessToken() ? this.oauth.getAccessToken() : null;
+  }
+  isLoggedIn(): boolean {
+    return this.oauth.hasValidIdToken() || this.oauth.hasValidAccessToken();
+  }
+}

--- a/frontend/src/app/auth/jwt.interceptor.ts
+++ b/frontend/src/app/auth/jwt.interceptor.ts
@@ -1,3 +1,17 @@
-export function jwtInterceptorPlaceholder(): void {
-  // TODO: implement JWT interceptor logic
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { AuthService } from './auth.service';
+
+@Injectable()
+export class JwtInterceptor implements HttpInterceptor {
+  constructor(private auth: AuthService) {}
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const token = this.auth.accessToken;
+    if (token) {
+      const cloned = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
+      return next.handle(cloned);
+    }
+    return next.handle(req);
+  }
 }

--- a/frontend/src/app/pages/auth-callback.component.ts
+++ b/frontend/src/app/pages/auth-callback.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { AuthService } from '../auth/auth.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-auth-callback',
+  template: `<p>Signing you in…</p>`,
+})
+export class AuthCallbackComponent implements OnInit {
+  constructor(private router: Router, private auth: AuthService) {}
+  async ngOnInit() {
+    await new Promise(r => setTimeout(r, 300));
+    this.router.navigateByUrl('/send');
+  }
+}

--- a/frontend/src/app/pages/home.component.ts
+++ b/frontend/src/app/pages/home.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  standalone: true,
+  selector: 'app-home',
+  template: `
+    <h1 class="h1">Volleyball Stats Messenger</h1>
+    <p>Send plain-text stat reports to your players. Log in to get started.</p>
+    <a routerLink="/send" class="btn">Go to Send Stats</a>
+  `,
+  imports: [RouterLink],
+  styles: [`
+    .h1{ margin:1rem 0; }
+    .btn{ display:inline-block; margin-top:1rem; padding:0.6rem 1rem; border:1px solid #ddd; border-radius:8px; text-decoration:none; }
+    .btn:hover{ background:#f6f6f6; }
+  `]
+})
+export class HomeComponent {}

--- a/frontend/src/app/pages/send-stats.component.ts
+++ b/frontend/src/app/pages/send-stats.component.ts
@@ -1,0 +1,81 @@
+import { Component } from '@angular/core';
+import { FormArray, FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { NgFor, NgIf } from '@angular/common';
+
+@Component({
+  standalone: true,
+  selector: 'app-send-stats',
+  template: `
+  <h2>Send Stats</h2>
+
+  <form [formGroup]="form" (ngSubmit)="onSubmit()" novalidate>
+    <div class="field">
+      <label for="playerId">Player ID</label>
+      <input id="playerId" type="text" formControlName="playerId" required aria-describedby="playerIdHelp">
+      <small id="playerIdHelp">Internal ID you use for this player.</small>
+      <div class="error" *ngIf="f.playerId.touched && f.playerId.invalid">Player ID is required.</div>
+    </div>
+
+    <div class="field">
+      <label for="playerEmail">Player Email</label>
+      <input id="playerEmail" type="email" formControlName="playerEmail" required aria-describedby="playerEmailHelp">
+      <small id="playerEmailHelp">This address will receive the report email.</small>
+      <div class="error" *ngIf="f.playerEmail.touched && f.playerEmail.invalid">Valid email is required.</div>
+    </div>
+
+    <fieldset class="field">
+      <legend>Categories</legend>
+
+      <div *ngFor="let group of categories.controls; let i = index" [formGroup]="group" class="row">
+        <input type="text" placeholder="Category (e.g., Aces)" formControlName="key" required>
+        <input type="text" placeholder="Value (e.g., 5)" formControlName="value" required>
+        <button type="button" (click)="removeCategory(i)" aria-label="Remove category">✕</button>
+      </div>
+
+      <button type="button" (click)="addCategory()">+ Add category</button>
+    </fieldset>
+
+    <button class="primary" type="submit" [disabled]="form.invalid">Preview (no send yet)</button>
+  </form>
+
+  <div class="preview" *ngIf="previewText">
+    <h3>Plain-text preview</h3>
+    <pre>{{ previewText }}</pre>
+  </div>
+  `,
+  styles: [`
+    form { max-width: 640px; display:grid; gap:1rem; }
+    .row { display:grid; grid-template-columns: 1fr 1fr auto; gap:0.5rem; align-items:center; }
+    .field { display:grid; gap:0.4rem; }
+    label { font-weight:600; }
+    input { padding:0.5rem; border:1px solid #ddd; border-radius:8px; }
+    .error { color:#b00020; font-size:0.85rem; }
+    button { border:1px solid #ddd; background:#fff; border-radius:8px; padding:0.4rem 0.8rem; cursor:pointer; }
+    button.primary { border-color:#333; }
+    .preview { margin-top:1.5rem; }
+    pre { background:#fafafa; border:1px solid #eee; padding:1rem; border-radius:8px; }
+  `],
+  imports: [ReactiveFormsModule, NgIf, NgFor]
+})
+export class SendStatsComponent {
+  form: FormGroup;
+  previewText = '';
+  get categories(): FormArray { return this.form.get('categories') as FormArray; }
+  get f() { return this.form.controls as any; }
+  constructor(private fb: FormBuilder) {
+    this.form = this.fb.group({
+      playerId: ['', Validators.required],
+      playerEmail: ['', [Validators.required, Validators.email]],
+      categories: this.fb.array([this.createCategory()])
+    });
+  }
+  createCategory(): FormGroup { return this.fb.group({ key: new FormControl('', Validators.required), value: new FormControl('', Validators.required) }); }
+  addCategory() { this.categories.push(this.createCategory()); }
+  removeCategory(i: number) { this.categories.removeAt(i); }
+  onSubmit() {
+    if (this.form.invalid) return;
+    const { playerId, playerEmail, categories } = this.form.value;
+    const lines = [`PlayerId: ${playerId}`, `PlayerEmail: ${playerEmail}`, ...categories.map((c: any) => `${c.key}: ${c.value}`)];
+    this.previewText = lines.join('\n');
+  }
+}

--- a/frontend/src/app/shared/navbar.component.ts
+++ b/frontend/src/app/shared/navbar.component.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { AuthService } from '../auth/auth.service';
+import { NgIf } from '@angular/common';
+
+@Component({
+  selector: 'app-navbar',
+  standalone: true,
+  imports: [RouterLink, NgIf],
+  template: `
+  <nav class="nav">
+    <a routerLink="/" class="brand">VSM</a>
+    <a routerLink="/send">Send Stats</a>
+    <span class="spacer"></span>
+    <button *ngIf="!auth.isLoggedIn()" (click)="auth.login()">Login</button>
+    <button *ngIf="auth.isLoggedIn()" (click)="auth.logout()">Logout</button>
+  </nav>
+  `,
+  styles: [`
+    .nav { display:flex; gap:1rem; align-items:center; padding:0.75rem 1rem; border-bottom:1px solid #eee;}
+    .brand { font-weight:600; }
+    .spacer { flex:1 }
+    button { border:1px solid #ddd; padding:0.4rem 0.8rem; border-radius:8px; background:#fff; cursor:pointer; }
+    button:hover { background:#f6f6f6; }
+  `]
+})
+export class NavbarComponent {
+  constructor(public auth: AuthService) {}
+}

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,3 +1,13 @@
 export const environment = {
   production: true,
+  apiBaseUrl: '/api',
+  cognito: {
+    region: 'us-east-1',
+    userPoolId: 'us-east-1_7Example',
+    clientId: '7exampleclientid1234567890',
+    hostedUiDomain: 'vsm-dev-portal.auth.us-east-1.amazoncognito.com',
+    redirectUri: 'http://localhost:4200/auth/callback',
+    postLogoutRedirectUri: 'http://localhost:4200/',
+    scope: 'openid profile email'
+  }
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,3 +1,13 @@
 export const environment = {
   production: false,
+  apiBaseUrl: 'http://localhost:8080',
+  cognito: {
+    region: 'us-east-1',
+    userPoolId: 'us-east-1_7Example',
+    clientId: '7exampleclientid1234567890',
+    hostedUiDomain: 'vsm-dev-portal.auth.us-east-1.amazoncognito.com',
+    redirectUri: 'http://localhost:4200/auth/callback',
+    postLogoutRedirectUri: 'http://localhost:4200/',
+    scope: 'openid profile email'
+  }
 };

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>VSM Portal</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/x-icon" href="favicon.ico">
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,13 @@
+import { enableProdMode } from '@angular/core';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
+import { AppModule } from './app/app.module';
+import { environment } from './environments/environment';
+
+if (environment.production) {
+  enableProdMode();
+}
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/frontend/src/polyfills.ts
+++ b/frontend/src/polyfills.ts
@@ -1,0 +1,1 @@
+import 'zone.js';

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,0 +1,21 @@
+@use "sass:map";
+
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  background-color: #ffffff;
+  color: #222;
+}
+
+main.container {
+  padding: 1.5rem;
+}
+
+a {
+  color: inherit;
+}

--- a/frontend/src/test.ts
+++ b/frontend/src/test.ts
@@ -1,0 +1,4 @@
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "useDefineForClassFields": false,
+    "lib": ["ES2021", "DOM"],
+    "skipLibCheck": true
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
+}

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "files": [
+    "src/test.ts",
+    "src/polyfills.ts"
+  ],
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold a full Angular workspace in the frontend directory with routing, testing, and build configuration
- add Cognito-backed OAuth service, guard, and JWT interceptor wired through the app module initializer
- implement navbar plus home, send-stats, and auth callback pages using standalone components and reactive forms

## Testing
