### PR TITLE
fix: import RouterLink in auth callback component

### DIFF
--- a/frontend/src/app/pages/auth-callback.component.ts
+++ b/frontend/src/app/pages/auth-callback.component.ts
@@ -1,8 +1,10 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-auth-callback',
   standalone: true,
+  imports: [RouterLink],
   template: `
     <h2>Auth Callback</h2>
     <p>You have been redirected back from login. If nothing happens, <a routerLink="/send">continue to Send Stats</a>.</p>


### PR DESCRIPTION
## Summary
- add the RouterLink directive to the standalone auth callback component so its template compiles when using routerLink

## Testing
- not run (not requested)