### PR TITLE
wire(auth): protect send route, register JwtInterceptor, initialize AuthService on startup

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -1,9 +1,10 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { AuthGuard } from './auth/auth.guard';
 
 const routes: Routes = [
   { path: '', loadComponent: () => import('./pages/home.component').then(m => m.HomeComponent) },
-  { path: 'send', loadComponent: () => import('./pages/send-stats.component').then(m => m.SendStatsComponent) },
+  { path: 'send', loadComponent: () => import('./pages/send-stats.component').then(m => m.SendStatsComponent), canActivate: [AuthGuard] },
   { path: 'auth/callback', loadComponent: () => import('./pages/auth-callback.component').then(m => m.AuthCallbackComponent) },
   { path: '**', redirectTo: '' }
 ];

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,13 +1,24 @@
-import { NgModule } from '@angular/core';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
 
+import { JwtInterceptor } from './auth/jwt.interceptor';
+import { AuthService } from './auth/auth.service';
+
+export function initAuth(auth: AuthService) {
+  return () => auth.init();
+}
+
 @NgModule({
   declarations: [AppComponent],
   imports: [BrowserModule, HttpClientModule, AppRoutingModule],
+  providers: [
+    { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true },
+    { provide: APP_INITIALIZER, useFactory: initAuth, deps: [AuthService], multi: true }
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule {}


### PR DESCRIPTION
This PR wires up three missing runtime pieces to enable the Day 4 auth flow:

Protect the /send route with AuthGuard so unauthenticated users are redirected to the Cognito Hosted UI.
Register JwtInterceptor as an HTTP_INTERCEPTOR so outgoing HttpClient requests include Authorization when available.
Add an APP_INITIALIZER to call AuthService.init() at app startup so the OAuth discovery document is loaded and the client can restore login state.
These changes are wiring-only: no behavioral changes to AuthService/JwtInterceptor/Guard themselves.
