### PR TITLE
Align Cognito configuration with hosted UI requirements

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,7 +1,4 @@
-<nav style="padding:12px; border-bottom:1px solid #eee; display:flex; gap:12px;">
-  <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}">Home</a>
-  <a routerLink="/send" routerLinkActive="active">Send Stats</a>
-</nav>
+<app-navbar></app-navbar>
 <main style="padding:16px;">
   <router-outlet></router-outlet>
 </main>

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { AppRoutingModule } from './app-routing.module';
 
 import { JwtInterceptor } from './auth/jwt.interceptor';
 import { AuthService } from './auth/auth.service';
+import { NavbarComponent } from './shared/navbar.component';
 
 export function initAuth(auth: AuthService) {
   return () => auth.init();
@@ -16,7 +17,7 @@ export function initAuth(auth: AuthService) {
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule, HttpClientModule, AppRoutingModule, OAuthModule.forRoot()],
+  imports: [BrowserModule, HttpClientModule, AppRoutingModule, OAuthModule.forRoot(), NavbarComponent],
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true },
     { provide: APP_INITIALIZER, useFactory: initAuth, deps: [AuthService], multi: true }

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -5,23 +5,30 @@ import { environment } from '../../environments/environment';
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private authConfig: AuthConfig = {
-    issuer: `https://cognito-idp.${environment.cognito.region}.amazonaws.com/${environment.cognito.userPoolId}`,
+    issuer: environment.cognito.issuer,
     clientId: environment.cognito.clientId,
     redirectUri: environment.cognito.redirectUri,
     postLogoutRedirectUri: environment.cognito.postLogoutRedirectUri,
-    responseType: 'code',
+    responseType: environment.cognito.responseType,
     scope: environment.cognito.scope,
     showDebugInformation: false,
     timeoutFactor: 0.75,
-    useSilentRefresh: false,
-    disablePKCE: false,
+    usePkce: environment.cognito.usePkce,
+    ...(environment.cognito.silentRefreshRedirectUri
+      ? {
+          useSilentRefresh: true,
+          silentRefreshRedirectUri: environment.cognito.silentRefreshRedirectUri,
+        }
+      : { useSilentRefresh: false }),
   };
 
   constructor(private oauth: OAuthService) {}
 
   async init(): Promise<void> {
     this.oauth.configure(this.authConfig);
-    this.oauth.setupAutomaticSilentRefresh();
+    if (environment.cognito.silentRefreshRedirectUri) {
+      this.oauth.setupAutomaticSilentRefresh();
+    }
     await this.oauth.loadDiscoveryDocumentAndTryLogin();
   }
 

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -4,10 +4,14 @@ export const environment = {
   cognito: {
     region: 'us-east-1',
     userPoolId: 'us-east-1_7Example',
+    issuer: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_7Example',
     clientId: '7exampleclientid1234567890',
     hostedUiDomain: 'vsm-dev-portal.auth.us-east-1.amazoncognito.com',
-    redirectUri: 'http://localhost:4200/auth/callback',
-    postLogoutRedirectUri: 'http://localhost:4200/',
-    scope: 'openid profile email'
+    redirectUri: 'https://vsm-dev-portal.pq.app/auth/callback',
+    postLogoutRedirectUri: 'https://vsm-dev-portal.pq.app/',
+    scope: 'openid profile email',
+    responseType: 'code',
+    usePkce: true,
+    silentRefreshRedirectUri: undefined,
   }
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -4,10 +4,14 @@ export const environment = {
   cognito: {
     region: 'us-east-1',
     userPoolId: 'us-east-1_7Example',
+    issuer: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_7Example',
     clientId: '7exampleclientid1234567890',
     hostedUiDomain: 'vsm-dev-portal.auth.us-east-1.amazoncognito.com',
     redirectUri: 'http://localhost:4200/auth/callback',
     postLogoutRedirectUri: 'http://localhost:4200/',
-    scope: 'openid profile email'
+    scope: 'openid profile email',
+    responseType: 'code',
+    usePkce: true,
+    silentRefreshRedirectUri: undefined,
   }
 };

--- a/infra/terraform/envs/dev/main.tf
+++ b/infra/terraform/envs/dev/main.tf
@@ -33,6 +33,14 @@ module "ddb" {
 module "cognito" {
   source      = "../../modules/cognito"
   name_prefix = var.name_prefix
+  callback_urls = [
+    "http://localhost:4200/auth/callback",
+    "https://${var.app_domain}/auth/callback",
+  ]
+  logout_urls = [
+    "http://localhost:4200/",
+    "https://${var.app_domain}/",
+  ]
 }
 
 module "ecr" {

--- a/infra/terraform/envs/dev/variables.tf
+++ b/infra/terraform/envs/dev/variables.tf
@@ -3,5 +3,6 @@ variable "name_prefix" { default = "vsm-dev" }
 variable "raw_bucket_name" { default = "vsm-raw-uploads-pq-dev" }
 variable "report_bucket_name" { default = "vsm-report-texts-pq-dev" }
 variable "ddb_table_name" { default = "vsm-main" }
+variable "app_domain" { default = "vsm-dev-portal.pq.app" }
 
 # ⚠️ Change the two S3 bucket names to globally unique values (e.g., add your initials) here or create dev.auto.tfvars with overrides.

--- a/infra/terraform/modules/cognito/main.tf
+++ b/infra/terraform/modules/cognito/main.tf
@@ -12,8 +12,8 @@ resource "aws_cognito_user_pool_client" "app" {
   allowed_oauth_scopes      = ["email", "openid", "profile"]
   allowed_oauth_flows_user_pool_client = true
   generate_secret           = false
-  callback_urls             = ["http://localhost:4200/callback"]
-  logout_urls               = ["http://localhost:4200"]
+  callback_urls             = var.callback_urls
+  logout_urls               = var.logout_urls
   supported_identity_providers = ["COGNITO"]
   explicit_auth_flows = ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
 }

--- a/infra/terraform/modules/cognito/variables.tf
+++ b/infra/terraform/modules/cognito/variables.tf
@@ -1,1 +1,11 @@
 variable "name_prefix" { type = string }
+
+variable "callback_urls" {
+  type    = list(string)
+  default = ["http://localhost:4200/auth/callback"]
+}
+
+variable "logout_urls" {
+  type    = list(string)
+  default = ["http://localhost:4200/"]
+}


### PR DESCRIPTION
## Summary
- add the missing Cognito OAuth metadata to the Angular environment files and AuthService configuration
- render the shared navbar inside the app shell so login and logout actions are accessible
- parameterize Cognito callback and logout URLs in Terraform and pass both localhost and hosted domains for the dev stack

## Testing
- npm run build *(fails: Angular CLI binaries unavailable because npm install cannot reach chokidar package)*

------
https://chatgpt.com/codex/tasks/task_e_68df33c54fa4832f820875b858f548d1